### PR TITLE
Correct php socket path in ssl configuration

### DIFF
--- a/build/default
+++ b/build/default
@@ -128,7 +128,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
         # With php5-fpm:
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/var/run/php5.6-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param REMOTE_ADDR $http_x_real_ip;


### PR DESCRIPTION
Hi,

I just put the right path in fastcgi_pass directive under the ssl configuration of nginx.